### PR TITLE
Fix Upstash env var names

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -34,10 +34,10 @@ Before you begin, ensure you have the following installed:
       cp .env.development .env
       ```
     - Edit the `.env` file and fill in the necessary values for services such as Upstash Redis, Upstash Vector, and Vercel. Refer to the "Set up environment variables for remote resources" section in `README.md` for a list of variables like:
-      - `UPSTASH_REDIS_URL`
-      - `UPSTASH_REDIS_TOKEN`
-      - `UPSTASH_VECTOR_URL`
-      - `UPSTASH_VECTOR_TOKEN`
+      - `UPSTASH_REDIS_REST_URL`
+      - `UPSTASH_REDIS_REST_TOKEN`
+      - `UPSTASH_VECTOR_REST_URL`
+      - `UPSTASH_VECTOR_REST_TOKEN`
       - `DATABASE_URL` (if overriding the default `file:local.db`)
       - `CORS_ALLOWED_ORIGINS` (defaults to `http://localhost:3000`)
 

--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ This is a Node.js application built with [Mastra](https://github.com/mastra-ai/m
 
     For Upstash/Vercel, you'll need to provide:
 
-    - `UPSTASH_REDIS_URL`
-    - `UPSTASH_REDIS_TOKEN`
-    - `UPSTASH_VECTOR_URL`
-    - `UPSTASH_VECTOR_TOKEN`
+    - `UPSTASH_REDIS_REST_URL`
+    - `UPSTASH_REDIS_REST_TOKEN`
+    - `UPSTASH_VECTOR_REST_URL`
+    - `UPSTASH_VECTOR_REST_TOKEN`
     - `VERCEL_TOKEN` (for deployment)
     - `VERCEL_TEAM_SLUG` (for deployment)
     - `VERCEL_PROJECT_NAME` (for deployment)

--- a/src/mastra/agents/memory.ts
+++ b/src/mastra/agents/memory.ts
@@ -54,21 +54,31 @@ function getUpstashMemory(): Memory {
 }
 
 function getUpstashStorageOptions() {
-  if (!process.env.UPSTASH_REDIS_URL || !process.env.UPSTASH_REDIS_TOKEN) {
-    throw new Error('UPSTASH_REDIS_URL and UPSTASH_REDIS_TOKEN are not set')
+  if (
+    !process.env.UPSTASH_REDIS_REST_URL ||
+    !process.env.UPSTASH_REDIS_REST_TOKEN
+  ) {
+    throw new Error(
+      'UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN are not set',
+    )
   }
   return {
-    url: process.env.UPSTASH_REDIS_URL,
-    token: process.env.UPSTASH_REDIS_TOKEN,
+    url: process.env.UPSTASH_REDIS_REST_URL,
+    token: process.env.UPSTASH_REDIS_REST_TOKEN,
   }
 }
 
 function getUpstashVectorOptions() {
-  if (!process.env.UPSTASH_VECTOR_URL || !process.env.UPSTASH_VECTOR_TOKEN) {
-    throw new Error('UPSTASH_VECTOR_URL and UPSTASH_VECTOR_TOKEN are not set')
+  if (
+    !process.env.UPSTASH_VECTOR_REST_URL ||
+    !process.env.UPSTASH_VECTOR_REST_TOKEN
+  ) {
+    throw new Error(
+      'UPSTASH_VECTOR_REST_URL and UPSTASH_VECTOR_REST_TOKEN are not set',
+    )
   }
   return {
-    url: process.env.UPSTASH_VECTOR_URL,
-    token: process.env.UPSTASH_VECTOR_TOKEN,
+    url: process.env.UPSTASH_VECTOR_REST_URL,
+    token: process.env.UPSTASH_VECTOR_REST_TOKEN,
   }
 }


### PR DESCRIPTION
## Summary
- update Upstash env variable names in docs
- correct Upstash env variable names in memory initialization

## Testing
- `npx prettier --write src/mastra/agents/memory.ts README.md DEVELOPMENT.md`
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_683f76a2a7fc8322af8f98e43cab41a5